### PR TITLE
patch: Add optional chaining in onrder to have nullable errors

### DIFF
--- a/lib/src/GQLResponse.dart
+++ b/lib/src/GQLResponse.dart
@@ -31,11 +31,7 @@ class GQLError {
   static List<GQLError> _getErrors(List<dynamic>? err) {
     if (err == null || err.isEmpty) return [];
     return err.map((e) {
-      try {
-        return GQLError(code: e['extensions']['code'], message: e['message']);
-      } catch (_) {
-        return GQLError(code: null, message: null);
-      }
+      return GQLError(code: e?['extensions']?['code'], message: e?['message']);
     }).toList();
   }
 


### PR DESCRIPTION
If we use Mercurius instead of apollo-server, it seems that errors has no "extensions" field, as we read `error["extensions"]["code"]` it went in the catch and put null in message field. So I've added optional chaining to write `null` in code field and the message in the message field if there is one. 